### PR TITLE
[Update]: Adapt to zig `nightly`

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -19,9 +19,10 @@ comptime {
 }
 
 pub fn build(b: *Build) void {
-    if (current_zig.minor == 11) {
-        build_11(b);
-    } else if (current_zig.minor == 12) {
-        build_12(b);
+    switch (current_zig.minor) {
+        11 => build_11(b),
+        12 => build_12(b),
+        13 => build_12(b),
+        else => @compileError("unknown version!"),
     }
 }

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -4,8 +4,8 @@
     .minimum_zig_version = "0.11.0",
     .dependencies = .{
         .webui = .{
-            .url = "https://github.com/webui-dev/webui/archive/32f876a0ae9da777dd7e1c793f5fba49c332d4f6.tar.gz",
-            .hash = "12200daaabfbcce59b4306fce987c7abf7f83415dcbd19ce185d697cad6721b48a4f",
+            .url = "https://github.com/webui-dev/webui/archive/4a63099003850a67272de7718d26a4f9fdcc8a6e.tar.gz",
+            .hash = "12206fcdd47d29c34db7fb175327c14cb34c8d4bbd10bfdf027fb897377f13b8ce24",
         },
     },
     .paths = .{


### PR DESCRIPTION
No changes for code logic, just adapt to zig `nightly`

Now, zig `0.12` has been released, zig `nightly` is `0.13`