### PR TITLE
feat: add api `setEventBlocking`

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -4,8 +4,8 @@
     .minimum_zig_version = "0.11.0",
     .dependencies = .{
         .webui = .{
-            .url = "https://github.com/webui-dev/webui/archive/926dd936cbfdbfde97cc6577fd928657c66b5e14.tar.gz",
-            .hash = "1220011d75df139f528fb5fc085b5346234db97a1a2874b04d76b70fcd96b7a41fd2",
+            .url = "https://github.com/webui-dev/webui/archive/02aeef647ef33dfa382d631eb96cd1abdb6249a8.tar.gz",
+            .hash = "1220533b3b87ab38626d62256b8d2a3b24532f36b2641773eb117b82f1fc37f379a5",
         },
     },
     .paths = .{

--- a/src/webui.zig
+++ b/src/webui.zig
@@ -74,10 +74,17 @@ pub const Events = enum(u8) {
 };
 
 pub const Config = enum(u8) {
-    // Control if `show()`,`webui_show_browser`,`webui_show_wv` should wait
-    // for the window to connect before returns or not.
-    // Default: True
+    /// Control if `show()`,`webui_show_browser`,`webui_show_wv` should wait
+    /// for the window to connect before returns or not.
+    /// Default: True
     show_wait_connection = 0,
+    /// Control if WebUI should block and process the UI events
+    /// one a time in a single thread `True`, or process every
+    /// event in a new non-blocking thread `False`. This updates
+    /// all windows. You can use `setEventBlocking()` for
+    /// a specific single window update.
+    /// Default: False
+    ui_event_blocking = 1,
 };
 
 /// Get the string length.
@@ -475,6 +482,14 @@ pub fn setPort(self: *Self, port: usize) bool {
 /// Control the WebUI behaviour. It's better to call at the beginning.
 pub fn setConfig(option: Config, status: bool) void {
     WebUI.webui_set_config(@intCast(@intFromEnum(option)), status);
+}
+
+/// Control if UI events comming from this window should be processed
+/// one a time in a single blocking thread `True`, or process every event in
+/// a new non-blocking thread `False`. This update single window. You can use
+/// `setConfig(ui_event_blocking, ...)` to update all windows.
+pub fn setEventBlocking(self: *Self, status: bool) void {
+    WebUI.webui_set_event_blocking(self.window_handle, status);
 }
 
 /// Set the SSL/TLS certificate and the private key content,


### PR DESCRIPTION
> Control if UI events comming from this window should be processed one a time in a single blocking thread `True`, or process every event in a new non-blocking thread `False`. This update single window. 
>
> You can use `setConfig(ui_event_blocking, ...)` to update all windows.