### PR TITLE
break change: support zig `0.14.0`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        version: [0.12.0, 0.13.0, ""]
+        version: [0.14.0, ""]
       fail-fast: false
     runs-on: ${{ matrix.os }}
     steps:

--- a/README.md
+++ b/README.md
@@ -47,7 +47,9 @@ Like `zig build run_minimal`, this will build and run the `minimal` example.
 
 ## Installation
 
-### Zig `0.12` \ `0.13.0` \ `nightly`
+> note: for `0.13.0` and previous version, please use tag `2.5.0-beta.2`
+
+### Zig `0.14.0` \ `nightly`
 
 > To be honest, I don’t recommend using the nightly version because the API of the build system is not yet stable, which means that there may be problems with not being able to build after nightly is updated.
 

--- a/build.zig
+++ b/build.zig
@@ -110,7 +110,13 @@ fn build_examples(b: *Build, optimize: OptimizeMode, target: Build.ResolvedTarge
 
     const examples_path = lazy_path.getPath(b);
 
-    var iter_dir = try std.fs.openDirAbsolute(examples_path, .{ .iterate = true });
+    var iter_dir = std.fs.openDirAbsolute(examples_path, .{ .iterate = true })
+        catch |err| {
+            switch (err) {
+                error.FileNotFound => return,
+                else => return err,
+            }
+        };
     defer iter_dir.close();
 
     var itera = iter_dir.iterate();

--- a/build.zig
+++ b/build.zig
@@ -39,7 +39,7 @@ pub fn build(b: *Build) !void {
         }
     }
 
-    // create a options for command paramter
+    // create a options for command parameter
     const flags_options = b.addOptions();
 
     // add option

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,7 +1,8 @@
 .{
-    .name = "zig-webui",
+    .name = .zig_webui,
     .version = "0.0.1",
     .minimum_zig_version = "0.12.0",
+    .fingerprint = 0x95965ed3cdfb8c33,
     .dependencies = .{
         .webui = .{
             .url = "https://github.com/webui-dev/webui/archive/c512af1e6c0fe62bdf458e00fefa456ce11a6cee.tar.gz",

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -5,11 +5,13 @@
     .fingerprint = 0x95965ed3cdfb8c33,
     .dependencies = .{
         .webui = .{
-            .url = "https://github.com/webui-dev/webui/archive/c512af1e6c0fe62bdf458e00fefa456ce11a6cee.tar.gz",
-            .hash = "1220100d77f4adf277ccc7d472952ed8ebef2e766c1225f3fbc56901bf4942e3c4dd",
+            .url = "https://github.com/webui-dev/webui/archive/5d497e3b839a93736be82107b333b4c0390dea2d.tar.gz",
+            .hash = "webui-2.5.0-beta.3-pxqD5WZmNgCLmrqQW0U_NI4iq-z706dyreyXr-e7kFmZ",
         },
     },
     .paths = .{
-        "",
+        "build.zig",
+        "build.zig.zon",
+        "src",
     },
 }


### PR DESCRIPTION
`0.14.0` has break change, so since this pr, zig-webui will not support `0.13.0` and previous version in the furture