### PR TITLE
do not fail on missing examples (when used as zig package)

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -110,7 +110,13 @@ fn build_examples(b: *Build, optimize: OptimizeMode, target: Build.ResolvedTarge
 
     const examples_path = lazy_path.getPath(b);
 
-    var iter_dir = try std.fs.openDirAbsolute(examples_path, .{ .iterate = true });
+    var iter_dir = std.fs.openDirAbsolute(examples_path, .{ .iterate = true })
+        catch |err| {
+            switch (err) {
+                error.FileNotFound => return,
+                else => return err,
+            }
+        };
     defer iter_dir.close();
 
     var itera = iter_dir.iterate();


### PR DESCRIPTION
before this:

```bash
$ zig build
error(WebUI): failed to build examples: error.FileNotFound
```

since "examples" is not in build.zig.zon, opening the examples dir fails, but we can ignore it imho
