### PR TITLE
Fix error reporting when signature of bound function is not void

### DIFF
--- a/src/webui.zig
+++ b/src/webui.zig
@@ -773,10 +773,11 @@ pub fn binding(self: webui, element: [:0]const u8, comptime callback: anytype) !
 
     const fnInfo = TInfo.@"fn";
     // Verify return type is void
-    if (fnInfo.return_type != void) {
+    const Ret = fnInfo.return_type orelse @compilerError("return_type can't be null");
+    if (Ret != void) {
         const err_msg = std.fmt.comptimePrint(
             "callback's return type ({}), it must be void!",
-            .{fnInfo.return_type},
+            .{Ret},
         );
         @compileError(err_msg);
     }

--- a/src/webui.zig
+++ b/src/webui.zig
@@ -773,7 +773,7 @@ pub fn binding(self: webui, element: [:0]const u8, comptime callback: anytype) !
 
     const fnInfo = TInfo.@"fn";
     // Verify return type is void
-    const Ret = fnInfo.return_type orelse @compilerError("return_type can't be null");
+    const Ret = fnInfo.return_type orelse @compileError("return_type can't be null");
     if (Ret != void) {
         const err_msg = std.fmt.comptimePrint(
             "callback's return type ({}), it must be void!",


### PR DESCRIPTION
Took a bit to figure out an error related to a bound (win.binding) function, I created, not returning void.
I was trying to return !void, to account for a try in the function.
With the current version I got an error summarized here: 

```
cannot format optional without a specifier (i.e. {?} or {any})
@compileError("cannot format optional without a specifier (i.e. {?} or {any})");
.../src/webui.zig:777:46: note: called from here const err_msg = std.fmt.comptimePrint(
```
This patch (really created by https://github.com/elpekenin) tries to offer a clearer response, as oppose to an error in the lib.