### PR TITLE
feat(webui): add focus and async wait bindings

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -5,8 +5,8 @@
     .minimum_zig_version = "0.14.0",
     .dependencies = .{
         .webui = .{
-            .hash = "webui-2.5.0-beta.4-pxqD5TfeNwBmDX91ECnjWAIQI_IUhqvWBk1yVo37FXLb",
-            .url = "https://github.com/webui-dev/webui/archive/f93b5a680c3c285d0d601081686347f7df4d0bc5.tar.gz",
+            .hash = "webui-2.5.0-beta.4-pxqD5a53OADNensyGsjVC_i_ksZ_G1enGSSsVD6p2dgg",
+            .url = "https://github.com/webui-dev/webui/archive/62bed203df456cb150bc088ed4f1b173526e9776.tar.gz",
         },
     },
     .paths = .{

--- a/src/c.zig
+++ b/src/c.zig
@@ -170,6 +170,13 @@ pub extern fn webui_show_wv(window: usize, content: [*:0]const u8) callconv(.c) 
 /// @example webui_set_kiosk(my_window, true);
 pub extern fn webui_set_kiosk(window: usize, status: bool) callconv(.c) void;
 
+/// @brief Bring a window to the front and focus it.
+///
+/// @param window The window number
+///
+/// @example webui_focus(myWindow);
+pub extern fn webui_focus(window: usize) callconv(.c) void;
+
 /// @brief Add a user-defined web browser's CLI parameters.
 ///
 /// @param window The window number
@@ -214,6 +221,16 @@ pub extern fn webui_browser_exist(browser: Browser) callconv(.c) bool;
 ///
 /// @example webui_wait();
 pub extern fn webui_wait() callconv(.c) void;
+
+/// @brief Wait asynchronously until all opened windows get closed.
+/// Note: In WebView mode, you need to call this from the main thread.
+///
+/// @return Returns True if more windows are still opened, False otherwise.
+///
+/// @example while (webui_wait_async()) {
+///    // Your main thread code here
+/// }
+pub extern fn webui_wait_async() callconv(.c) bool;
 
 /// @brief Close a specific window only. The window object will still exist.
 /// All clients.

--- a/src/webui.zig
+++ b/src/webui.zig
@@ -165,6 +165,11 @@ pub fn setKiosk(self: webui, status: bool) void {
     c.webui_set_kiosk(self.window_handle, status);
 }
 
+/// Bring a window to the front and focus it.
+pub fn focus(self: webui) void {
+    c.webui_focus(self.window_handle);
+}
+
 /// Add a user-defined web browser's CLI parameters.
 pub fn setCustomParameters(self: webui, params: [:0]const u8) void {
     c.webui_set_custom_parameters(self.window_handle, params.ptr);
@@ -194,6 +199,12 @@ pub fn browserExist(browser: Browser) bool {
 /// This function should be **called** at the end, it will **block** the current thread
 pub fn wait() void {
     c.webui_wait();
+}
+
+/// Wait asynchronously until all opened windows get closed.
+/// Returns `true` while there are still windows open.
+pub fn waitAsync() bool {
+    return c.webui_wait_async();
 }
 
 /// Set a custom logger function.


### PR DESCRIPTION
Add `webui_focus()` to bring windows to front, and `webui_wait_async()` for non-blocking window closure checks. Update to latest webui beta.